### PR TITLE
Change documentation to use `run-id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action takes two values as input and adds them together.
 
 **Required** The base build number. 
 
-## `run_id`
+## `run-id`
 
 **Required** The `GITHUB_RUN_NUMBER` which should be provided 
 as `${GITHUB_RUN_NUMBER}`
@@ -29,5 +29,5 @@ The inputs added together
 uses: mlilback/build-number@v1
 with:
   base: 100
-  run_id: ${GITHUB_RUN_NUMBER}
+  run-id: ${GITHUB_RUN_NUMBER}
 ```


### PR DESCRIPTION
The documentation previously used `run_id` instead of `run-id` which is what is specified in actions.yml.