### PR TITLE
use node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,19 +1,19 @@
-name: 'Build Number (with base)'
-author: 'Mark Lilback'
-description: 'Takes a base number and returns it + GITHUB_RUN_NUMBER'
+name: "Build Number (with base)"
+author: "Mark Lilback"
+description: "Takes a base number and returns it + GITHUB_RUN_NUMBER"
 inputs:
   base:
-    description: 'Base build number'
+    description: "Base build number"
     required: true
   run-id:
-    description: 'The GITHUB_RUN_NUMBER environment variable'
+    description: "The GITHUB_RUN_NUMBER environment variable"
     required: true
 outputs:
   build-number:
-    description: 'The derived build number'
+    description: "The derived build number"
 runs:
-  using: 'node16'
-  main: 'main.js'
+  using: "node20"
+  main: "main.js"
 branding:
-  color: 'purple'
-  icon: 'plus'
+  color: "purple"
+  icon: "plus"

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Build Number (with base)"
+name: "Build Number (with base), node20"
 author: "Mark Lilback"
 description: "Takes a base number and returns it + GITHUB_RUN_NUMBER"
 inputs:


### PR DESCRIPTION
Closes https://github.com/mlilback/build-number/issues/4

Upgrades to node 20.

In the meantime, I did a release from my own fork here: https://github.com/marketplace/actions/build-number-with-base-node20

I hope you don't mind. I'm hoping you'll see this and merge this in soon, so I can then remove my version. I did this because we're getting warnings in our pipelines due to node16 being deprecated.

Thanks!